### PR TITLE
Fix tests, by using a different type to parse outgoing/incoming

### DIFF
--- a/src/formats.rs
+++ b/src/formats.rs
@@ -67,16 +67,5 @@ pub enum ErrorKind {
     },
 }
 
-impl Outgoing {
-    #[cfg(test)]
-    pub fn request_id(&self) -> ReqId {
-        match self {
-            Outgoing::Next { request_id, .. } => *request_id,
-            Outgoing::Complete { request_id, .. } => *request_id,
-            Outgoing::Error { request_id, .. } => *request_id,
-        }
-    }
-}
-
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Hash, PartialEq, Eq)]
 pub struct ReqId(pub u64);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -409,25 +409,22 @@ mod tests {
     #[serde(tag = "type")]
     #[serde(rename_all = "camelCase")]
     pub enum OutgoingAst {
-	#[serde(rename_all = "camelCase")]
-	Next {
-            request_id: ReqId,
-            payload: Value,
-	},
-	#[serde(rename_all = "camelCase")]
-	Complete { request_id: ReqId },
-	#[serde(rename_all = "camelCase")]
-	Error { request_id: ReqId, kind: ErrorKind },
+        #[serde(rename_all = "camelCase")]
+        Next { request_id: ReqId, payload: Value },
+        #[serde(rename_all = "camelCase")]
+        Complete { request_id: ReqId },
+        #[serde(rename_all = "camelCase")]
+        Error { request_id: ReqId, kind: ErrorKind },
     }
 
     impl OutgoingAst {
-	pub fn request_id(&self) -> ReqId {
+        pub fn request_id(&self) -> ReqId {
             match self {
-		OutgoingAst::Next { request_id, .. } => *request_id,
-		OutgoingAst::Complete { request_id, .. } => *request_id,
-		OutgoingAst::Error { request_id, .. } => *request_id,
+                OutgoingAst::Next { request_id, .. } => *request_id,
+                OutgoingAst::Complete { request_id, .. } => *request_id,
+                OutgoingAst::Error { request_id, .. } => *request_id,
             }
-	}
+        }
     }
 
     fn test_client<Req: Serialize, Resp: DeserializeOwned>(


### PR DESCRIPTION
Could also parameterize `Outgoing` but imo not worth the complication. We should rather get the approach in #1 working at some point.